### PR TITLE
fix: lazily import dim_reduction to avoid unconditional statsmodels dependency on package load

### DIFF
--- a/coco_pipe/__init__.py
+++ b/coco_pipe/__init__.py
@@ -8,23 +8,7 @@ from .descriptors import (
     DescriptorConfig,
     DescriptorPipeline,
 )
-from .dim_reduction import (
-    METHODS,
-    BaseReducer,
-    DimReduction,
-    IncrementalPCAReducer,
-    IsomapReducer,
-    LLEReducer,
-    MDSReducer,
-    PCAReducer,
-    SpectralEmbeddingReducer,
-    TSNEReducer,
-    continuity,
-    interpret_features,
-    lcmc,
-    shepard_diagram_data,
-    trustworthiness,
-)
+
 from .utils import get_environment_info, get_git_revision_hash, get_package_version
 
 if TYPE_CHECKING:
@@ -62,12 +46,20 @@ if TYPE_CHECKING:
         UMAPReducer as UMAPReducer,
     )
 
-# Core exports
+# Core exports (non-dim_reduction names only; dim_reduction names are added
+# below via __all__.extend(_LAZY_DIM_REDUCTION_EXPORTS) to avoid duplicates)
 __all__ = [
-    "METHODS",
-    "BaseReducer",
     "DescriptorConfig",
     "DescriptorPipeline",
+    "get_environment_info",
+    "get_git_revision_hash",
+    "get_package_version",
+]
+
+_LAZY_DIM_REDUCTION_EXPORTS = {
+    # sklearn-based reducers — always available once scikit-learn is installed
+    "METHODS",
+    "BaseReducer",
     "DimReduction",
     "IncrementalPCAReducer",
     "IsomapReducer",
@@ -76,17 +68,13 @@ __all__ = [
     "PCAReducer",
     "SpectralEmbeddingReducer",
     "TSNEReducer",
+    # evaluation helpers
     "continuity",
-    "get_environment_info",
-    "get_git_revision_hash",
-    "get_package_version",
     "interpret_features",
     "lcmc",
     "shepard_diagram_data",
     "trustworthiness",
-]
-
-_LAZY_DIM_REDUCTION_EXPORTS = {
+    # optional reducers that require extra dependencies
     "UMAPReducer",
     "PacmapReducer",
     "TrimapReducer",

--- a/coco_pipe/dim_reduction/evaluation/stats.py
+++ b/coco_pipe/dim_reduction/evaluation/stats.py
@@ -22,7 +22,6 @@ from itertools import combinations
 import numpy as np
 import pandas as pd
 from scipy.stats import ttest_rel
-from statsmodels.stats.multitest import multipletests
 
 __all__ = [
     "grouped_condition_stats",
@@ -106,6 +105,15 @@ def paired_condition_stats(
                 "p_fdr",
             ]
         )
+
+    try:
+        from statsmodels.stats.multitest import multipletests
+    except ImportError as exc:
+        raise ImportError(
+            "'statsmodels' is required for FDR correction in paired_condition_stats. "
+            "Install it with: pip install statsmodels  "
+            "(or: pip install 'coco-pipe[dim-red]')"
+        ) from exc
 
     out = pd.DataFrame(rows)
     _, p_fdr, _, _ = multipletests(out["p_uncorrected"].fillna(1.0), method="fdr_bh")
@@ -203,6 +211,15 @@ def grouped_condition_stats(
                 "p_fdr",
             ]
         )
+
+    try:
+        from statsmodels.stats.multitest import multipletests
+    except ImportError as exc:
+        raise ImportError(
+            "'statsmodels' is required for FDR correction in grouped_condition_stats. "
+            "Install it with: pip install statsmodels  "
+            "(or: pip install 'coco-pipe[dim-red]')"
+        ) from exc
 
     out = pd.DataFrame(rows)
     _, p_fdr, _, _ = multipletests(out["p_uncorrected"].fillna(1.0), method="fdr_bh")


### PR DESCRIPTION
fixes #20: importing coco_pipe unconditionally required statsmodels even for users who never used dim_reduction, fixed this by moving the eager from.dim_reduction import ... block in __init__.py into the existing lazy-loading machinery, and deferring the form statsmodels ... import multipletests inside the two functions that actually need it