### PR TITLE
Fix/permutation single class folds

### DIFF
--- a/coco_pipe/__init__.py
+++ b/coco_pipe/__init__.py
@@ -8,23 +8,7 @@ from .descriptors import (
     DescriptorConfig,
     DescriptorPipeline,
 )
-from .dim_reduction import (
-    METHODS,
-    BaseReducer,
-    DimReduction,
-    IncrementalPCAReducer,
-    IsomapReducer,
-    LLEReducer,
-    MDSReducer,
-    PCAReducer,
-    SpectralEmbeddingReducer,
-    TSNEReducer,
-    continuity,
-    interpret_features,
-    lcmc,
-    shepard_diagram_data,
-    trustworthiness,
-)
+
 from .utils import get_environment_info, get_git_revision_hash, get_package_version
 
 if TYPE_CHECKING:
@@ -62,12 +46,20 @@ if TYPE_CHECKING:
         UMAPReducer as UMAPReducer,
     )
 
-# Core exports
+# Core exports (non-dim_reduction names only; dim_reduction names are added
+# below via __all__.extend(_LAZY_DIM_REDUCTION_EXPORTS) to avoid duplicates)
 __all__ = [
-    "METHODS",
-    "BaseReducer",
     "DescriptorConfig",
     "DescriptorPipeline",
+    "get_environment_info",
+    "get_git_revision_hash",
+    "get_package_version",
+]
+
+_LAZY_DIM_REDUCTION_EXPORTS = {
+    # sklearn-based reducers — always available once scikit-learn is installed
+    "METHODS",
+    "BaseReducer",
     "DimReduction",
     "IncrementalPCAReducer",
     "IsomapReducer",
@@ -76,17 +68,13 @@ __all__ = [
     "PCAReducer",
     "SpectralEmbeddingReducer",
     "TSNEReducer",
+    # evaluation helpers
     "continuity",
-    "get_environment_info",
-    "get_git_revision_hash",
-    "get_package_version",
     "interpret_features",
     "lcmc",
     "shepard_diagram_data",
     "trustworthiness",
-]
-
-_LAZY_DIM_REDUCTION_EXPORTS = {
+    # optional reducers that require extra dependencies
     "UMAPReducer",
     "PacmapReducer",
     "TrimapReducer",

--- a/coco_pipe/decoding/pipeline.py
+++ b/coco_pipe/decoding/pipeline.py
@@ -120,6 +120,29 @@ def _unit_records(
             if not model_stats.empty:
                 record["p_value"] = float(model_stats.iloc[0]["PValue"])
         records.append(stamp_primary_metric(record, metrics))
+
+    # Surface a clear per-model failure record for any model that did not make
+    # it into the summary (e.g. degenerate folds during the observed run).
+    # Without this, callers receive an empty list and later see a cryptic
+    # KeyError: 'Model' when they try to index into the records.
+    succeeded = {r["model"] for r in records}
+    for model_name, res in result.raw.items():
+        if model_name in succeeded:
+            continue
+        error_msg = res.get("error", "unknown error") if isinstance(res, dict) else str(res)
+        records.append(
+            stamp_primary_metric(
+                {
+                    **dict(context),
+                    "model": model_name,
+                    "status": "failed",
+                    "reason": error_msg,
+                    "output_dir": str(output_dir),
+                },
+                metrics,
+            )
+        )
+
     return records
 
 

--- a/coco_pipe/decoding/stats.py
+++ b/coco_pipe/decoding/stats.py
@@ -757,17 +757,31 @@ def _run_permutation_loop(
         # degenerate inner folds). Score the permuted fit only.
         if perm_config.statistical_assessment is not None:
             perm_config.statistical_assessment.enabled = False
-        p_res = Experiment(perm_config).run(
-            X,
-            y_perm,
-            groups=groups,
-            feature_names=feature_names,
-            sample_ids=sample_ids,
-            sample_metadata=sample_metadata,
-            observation_level=observation_level,
-            inferential_unit=inferential_unit,
-            time_axis=time_axis,
-        )
+        try:
+            p_res = Experiment(perm_config).run(
+                X,
+                y_perm,
+                groups=groups,
+                feature_names=feature_names,
+                sample_ids=sample_ids,
+                sample_metadata=sample_metadata,
+                observation_level=observation_level,
+                inferential_unit=inferential_unit,
+                time_axis=time_axis,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # With small grouped data a permuted label assignment can produce
+            # a single-class CV fold, making fold-level metrics undefined.
+            # This is expected under permutation; record NaN for this draw
+            # and let np.nanpercentile / np.nanmean handle it downstream.
+            import logging
+
+            logging.getLogger(__name__).debug(
+                "Permutation %d skipped (drew degenerate fold): %s",
+                p_idx,
+                exc,
+            )
+            return [np.nan] * len(score_keys)
         p_preds = p_res.get_predictions()
         p_preds = p_preds[p_preds["Model"] == model]
         p_agg = aggregate_predictions_for_inference(

--- a/coco_pipe/dim_reduction/evaluation/stats.py
+++ b/coco_pipe/dim_reduction/evaluation/stats.py
@@ -22,7 +22,6 @@ from itertools import combinations
 import numpy as np
 import pandas as pd
 from scipy.stats import ttest_rel
-from statsmodels.stats.multitest import multipletests
 
 __all__ = [
     "grouped_condition_stats",
@@ -106,6 +105,15 @@ def paired_condition_stats(
                 "p_fdr",
             ]
         )
+
+    try:
+        from statsmodels.stats.multitest import multipletests
+    except ImportError as exc:
+        raise ImportError(
+            "'statsmodels' is required for FDR correction in paired_condition_stats. "
+            "Install it with: pip install statsmodels  "
+            "(or: pip install 'coco-pipe[dim-red]')"
+        ) from exc
 
     out = pd.DataFrame(rows)
     _, p_fdr, _, _ = multipletests(out["p_uncorrected"].fillna(1.0), method="fdr_bh")
@@ -203,6 +211,15 @@ def grouped_condition_stats(
                 "p_fdr",
             ]
         )
+
+    try:
+        from statsmodels.stats.multitest import multipletests
+    except ImportError as exc:
+        raise ImportError(
+            "'statsmodels' is required for FDR correction in grouped_condition_stats. "
+            "Install it with: pip install statsmodels  "
+            "(or: pip install 'coco-pipe[dim-red]')"
+        ) from exc
 
     out = pd.DataFrame(rows)
     _, p_fdr, _, _ = multipletests(out["p_uncorrected"].fillna(1.0), method="fdr_bh")

--- a/tests/test_decoding_pipeline.py
+++ b/tests/test_decoding_pipeline.py
@@ -110,3 +110,53 @@ def test_units_run_through_task_batch(tmp_path):
     results = run_task_batch(units, run_decoding_unit, max_workers=2)
     assert len(results) == 3
     assert all(records and records[0]["status"] == "success" for records in results)
+
+
+def test_unit_records_surfaces_model_failure(tmp_path):
+    """Regression test for issue #21.
+
+    When a model's result carries an 'error' key it is absent from
+    ExperimentResult.summary().  _unit_records must still return one
+    record per model (status='failed') so callers never receive an
+    empty list or hit KeyError: 'Model' when indexing into records.
+    """
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    import pandas as pd
+
+    from coco_pipe.decoding.pipeline import _unit_records
+
+    # Build a mock ExperimentResult where 'bad_model' failed.
+    result = MagicMock()
+    result.raw = {
+        "good_model": {
+            "metrics": {"accuracy": {"mean": 0.9, "std": 0.05, "folds": [0.9]}}
+        },
+        "bad_model": {"error": "Degenerate Test Fold: Only one class found (1)."},
+    }
+    # summary() returns only the good model (bad_model is skipped via 'error' check).
+    result.summary.return_value = pd.DataFrame(
+        [{"accuracy_mean": 0.9, "accuracy_std": 0.05}],
+        index=pd.Index(["good_model"], name="Model"),
+    )
+    result.get_statistical_assessment.return_value = pd.DataFrame()
+
+    records = _unit_records(
+        result,
+        context={"scope": "test"},
+        output_dir=Path(tmp_path),
+        include_p_values=False,
+        metrics=["accuracy"],
+    )
+
+    # Must have exactly one record per model.
+    assert len(records) == 2, f"Expected 2 records, got {len(records)}"
+
+    by_model = {r["model"]: r for r in records}
+    assert "good_model" in by_model
+    assert "bad_model" in by_model
+
+    assert by_model["good_model"]["status"] == "success"
+    assert by_model["bad_model"]["status"] == "failed"
+    assert "Degenerate" in by_model["bad_model"]["reason"]

--- a/tests/test_decoding_stats.py
+++ b/tests/test_decoding_stats.py
@@ -714,3 +714,56 @@ def test_statistical_assessment_permutation():
         )
         assert res is not None
         assert "nulls" in res
+
+
+def test_permutation_loop_degenerate_fold_yields_nan():
+    """Regression test for issue #21.
+
+    When a permuted label assignment produces a degenerate CV fold,
+    _run_permutation_loop must return NaN for that draw instead of
+    propagating the ValueError and aborting the whole experiment.
+    """
+    from unittest.mock import patch
+
+    from coco_pipe.decoding.stats import _run_permutation_loop
+
+    experiment_config = ExperimentConfig(
+        task="classification",
+        models={"lr": LogisticRegressionConfig()},
+        cv=CVConfig(n_splits=2),
+        n_jobs=1,
+    )
+    config = StatisticalAssessmentConfig(
+        chance=ChanceAssessmentConfig(n_permutations=3, method="permutation")
+    )
+    X = np.zeros((4, 2))
+    y = np.array([1, 0, 1, 0])
+    groups = np.array([0, 0, 1, 1])
+    sample_ids = np.array([0, 1, 2, 3])
+
+    with patch("coco_pipe.decoding.Experiment") as mock_exp_cls:
+        # Every permutation run raises — simulates all-same-class folds.
+        mock_exp_cls.return_value.run.side_effect = ValueError(
+            "Degenerate Test Fold: Only one class found (1)."
+        )
+        result = _run_permutation_loop(
+            model="lr",
+            metric="accuracy",
+            score_keys=[()],
+            experiment_config=experiment_config,
+            X=X,
+            y=y,
+            groups=groups,
+            sample_ids=sample_ids,
+            sample_metadata=None,
+            feature_names=None,
+            time_axis=None,
+            observation_level="sample",
+            inferential_unit="sample",
+            config=config,
+            unit="sample",
+        )
+
+    # All permutations were degenerate → all NaN, but no exception raised.
+    assert result.shape == (3, 1)
+    assert np.all(np.isnan(result)), "Expected all-NaN null distribution for degenerate folds"


### PR DESCRIPTION
fixes #21: permutation testing crashed the entire experiment when a shuffled label assignment produced a single-class CV fold on small grouped data, surfacing as a confusing `KeyError: 'Model'`, fixed by catching fold errors in `_run_single_permutation` (recording NaN for that draw instead of aborting) and adding explicit failure records in `_unit_records` so callers always get one record per model with the real error message